### PR TITLE
Find example k8s configurations

### DIFF
--- a/examples/eks-dynamic/k8s/pod.yaml
+++ b/examples/eks-dynamic/k8s/pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-dynamic-test-pod
+spec:
+  containers:
+  - name: app
+    image: public.ecr.aws/docker/library/busybox:1.36
+    command: ["sh", "-c", "echo $(date) > /data/hello && sleep 3600"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: ebs-pvc-dynamic

--- a/examples/eks-dynamic/k8s/pvc.yaml
+++ b/examples/eks-dynamic/k8s/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-pvc-dynamic
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ebs-gp3

--- a/examples/eks-dynamic/k8s/storageclass.yaml
+++ b/examples/eks-dynamic/k8s/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-gp3
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  fsType: ext4

--- a/examples/eks-static/k8s/pod.yaml
+++ b/examples/eks-static/k8s/pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-test-pod
+spec:
+  containers:
+  - name: app
+    image: public.ecr.aws/docker/library/busybox:1.36
+    command: ["sh", "-c", "echo $(date) > /data/hello && sleep 3600"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: ebs-pvc-static


### PR DESCRIPTION
Add missing Kubernetes example configurations for static and dynamic EBS provisioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-c22024b2-5355-4fcf-b4a2-8819525b8f0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c22024b2-5355-4fcf-b4a2-8819525b8f0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

